### PR TITLE
Add django admin view for jobs model

### DIFF
--- a/pgq/admin.py
+++ b/pgq/admin.py
@@ -1,0 +1,16 @@
+from django.contrib import admin
+
+from . import settings
+from .models import Job
+
+
+class JobAdmin(admin.ModelAdmin):
+    list_display = ("task", "queue", "created_at", "execute_at", "priority")
+
+    def has_add_permission(self, request):
+        # Hide the admin "+ Add" link for Jobs
+        return False
+
+
+if settings.SHOW_JOBS_ADMIN:
+    admin.site.register(Job, JobAdmin)

--- a/pgq/settings.py
+++ b/pgq/settings.py
@@ -1,0 +1,10 @@
+"""
+For the full list of settings and their values, see
+https://docs.djangoproject.com/en/4.1/ref/settings/
+
+isort:skip_file
+"""
+from django.conf import settings
+
+
+SHOW_JOBS_ADMIN = getattr(settings, "SHOW_JOBS_ADMIN", True)

--- a/testproj/settings.py
+++ b/testproj/settings.py
@@ -81,6 +81,8 @@ DATABASES = {
         "NAME": "pgq_testproj",
         "USER": "pgq",
         "PASSWORD": "pgq",
+        "HOST": "localhost",
+        "PORT": "5432",
     }
 }
 


### PR DESCRIPTION
# Summary
 - This PR adds a basic django admin view for mishka jobs
 - It can be exposed/hidden through the `SHOW_JOBS_ADMIN` settings variable

![Screenshot from 2022-11-11 12-05-32](https://user-images.githubusercontent.com/9034588/201337073-6742bbbf-c87f-4153-b034-2d5994cd6299.png)

# Steps to test this change
 - Run the mishka test project
 - Create a queue, enqueue some jobs to this queue
 - Go to the django admin and click 'Jobs'
 - You should see the jobs you just created
 - In `testproj/settings.py` add the var `SHOW_JOBS_ADMIN = False`
 - 'Jobs' should no longer be present in the django admin