### PR TITLE
PFM-94: Eager mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,18 +369,11 @@ These recipes aren't officially supported features of <span
 class="title-ref">mishka-queue</span>. We provide them so that you
 can mimick some of the common features in other task queues.
 
-# `CELERY_ALWAYS_EAGER`
+# `QUEUE_ALWAYS_EAGER`
 
-Celery uses the `CELERY_ALWAYS_EAGER`
+The queues in this library allow you to use the `QUEUE_ALWAYS_EAGER`
 setting to run a task immediately, without queueing it for a worker. It
 could be used during tests, and while debugging in a development
 environment with any workers turned off.
 
-``` python
-class EagerAtLeastOnceQueue(AtLeastOnceQueue):
-    def enqueue(self, *args, **kwargs):
-        job = super().enqueue(*args, **kwargs)
-        if settings.QUEUE_ALWAYS_EAGER:
-            self.run_job(job)
-        return job
-```
+It is similar in behaviour to `CELERY_ALWAYS_EAGER` setting in Celery.

--- a/pgq/queue.py
+++ b/pgq/queue.py
@@ -23,6 +23,7 @@ from django.db import connection, transaction
 
 from .exceptions import PgqException
 from .models import DEFAULT_QUEUE_NAME, BaseJob, Job
+from .settings import QUEUE_ALWAYS_EAGER
 
 _Job = TypeVar("_Job", bound=BaseJob)
 # mypy doesn't support binding to BaseQueue[_Job] and may never do so...
@@ -205,6 +206,12 @@ class BaseQueue(Generic[_Job], metaclass=abc.ABCMeta):
 
 class Queue(BaseQueue[Job]):
     job_model = Job
+
+    def enqueue(self, *args, **kwargs):
+        job = super().enqueue(*args, **kwargs)
+        if QUEUE_ALWAYS_EAGER:
+            self.run_job(job)
+        return job
 
 
 class AtMostOnceQueue(Queue):

--- a/pgq/settings.py
+++ b/pgq/settings.py
@@ -8,3 +8,4 @@ from django.conf import settings
 
 
 SHOW_JOBS_ADMIN = getattr(settings, "SHOW_JOBS_ADMIN", True)
+QUEUE_ALWAYS_EAGER = getattr(settings, "QUEUE_ALWAYS_EAGER", False)


### PR DESCRIPTION
# Summary
 - Add the ability to use eager mode to the `Queue` class, so applications that integrate with this library do not need to do this themselves
 - Update the README
 - Add default `QUEUE_ALWAYS_EAGER` variable in a way that be overridden by implementer
