### PR TITLE
Add queue size helper

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         name: poetry-install
         stages: [commit]
         language: system
-        entry: poetry install
+        entry: poetry install --sync --with dev
         pass_filenames: false
         always_run: true
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,8 +25,8 @@ repos:
         entry: poetry run black
         types: [python]
 
-      - id: black
-        name: black
+      - id: flake8
+        name: flake8
         stages: [commit]
         language: system
         entry: poetry run flake8 pgq/

--- a/pgq/queue.py
+++ b/pgq/queue.py
@@ -119,7 +119,6 @@ class BaseQueue(Generic[_Job], metaclass=abc.ABCMeta):
         kwargs_list: Sequence[Dict[str, Any]],
         batch_size: Optional[int] = None,
     ) -> List[_Job]:
-
         assert task in self.tasks
 
         jobs = self.job_model.objects.bulk_create(
@@ -202,6 +201,10 @@ class BaseQueue(Generic[_Job], metaclass=abc.ABCMeta):
         except Exception as e:
             # Add job info to exception to be accessible for logging.
             raise PgqException(job=job) from e
+
+    def size(self):
+        """Return the number of jobs in the queue."""
+        return self.job_model.objects.filter(queue=self.queue).count()
 
 
 class Queue(BaseQueue[Job]):

--- a/testproj/tests.py
+++ b/testproj/tests.py
@@ -34,6 +34,16 @@ class PgqQueueTests(TestCase):
         self.assertEqual(job.args["count"], 5)
         self.assertEqual(job.queue, NAME)
 
+    def test_queue_size_helper(self) -> None:
+        """
+        Creates a basic queue with a name, and puts the job onto the queue.
+        """
+        NAME = "machine_a"
+        queue = AtLeastOnceQueue(tasks={"demotask": demotask}, queue=NAME)
+
+        queue.enqueue("demotask", {"count": 5})
+        assert queue.size() == 1
+
     def test_job_contained_to_queue(self) -> None:
         """
         Test that a job added to one queue won't be visible on another queue.


### PR DESCRIPTION
Adds a `.size()` method to the queue in order to get the currently queued jobs. Does not currently account for in-progress tasks which will be not counted if on an `AtMostOnceQueue`, but will be counted if on an `AtLeastOnceQueue`