### PR TITLE
Fix: remove transaction wrap

### DIFF
--- a/pgq/decorators.py
+++ b/pgq/decorators.py
@@ -84,10 +84,9 @@ def retry(
 
             try:
                 args = copy.deepcopy(job.args)
-                with transaction.atomic():
-                    result = fn(
-                        queue, job, args["func_args"], JobMetaType(**args["meta"])
-                    )
+                result = fn(
+                    queue, job, args["func_args"], JobMetaType(**args["meta"])
+                )
             except Exc as e:
                 retries = job.args["meta"].get("retries", 0)
                 if retries < max_retries:

--- a/pgq/decorators.py
+++ b/pgq/decorators.py
@@ -6,8 +6,6 @@ import random
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Type
 
-from django.db import transaction
-
 if TYPE_CHECKING:
     from .models import BaseJob
     from .queue import Queue

--- a/pgq/decorators.py
+++ b/pgq/decorators.py
@@ -84,9 +84,7 @@ def retry(
 
             try:
                 args = copy.deepcopy(job.args)
-                result = fn(
-                    queue, job, args["func_args"], JobMetaType(**args["meta"])
-                )
+                result = fn(queue, job, args["func_args"], JobMetaType(**args["meta"]))
             except Exc as e:
                 retries = job.args["meta"].get("retries", 0)
                 if retries < max_retries:


### PR DESCRIPTION
Whilst the current wrapping does prevent partial tasks from being committed, it also means that transactions cannot be used within the scope of a task.